### PR TITLE
Patch for warning about setup property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/
 dist/
 build/
 Epilogos.egg-info/
+epilogos.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,7 @@
 graft data/
-global exclude *.png
+global-exclude *.png
 graft bin/
 include *.txt
 prune build/
 prune src/
 prune epilogos/__pycache__/
-
-

--- a/README.md
+++ b/README.md
@@ -728,6 +728,26 @@ This is consistent with our knowledge of these loci playing crucial roles in the
   <img src="https://raw.githubusercontent.com/meuleman/epilogos/main/data/manhattan_male_female_chrX.png" width="840">
 </h1>
 
+## Development
 
+To modify a development version of `epilogos`, first set up a virtual environment via `venv` or `conda`. After activating the environment and installing [dependencies](#prerequisites), install `epilogos` in develop or editable mode:
 
+```bash
+$ pip install -e .
+```
 
+### Big Sur
+
+If you are using Mac OS X 11 (Big Sur) or later, it may be necessary to first install OpenBLAS, before installing Python dependencies that require it (such as `scipy`). 
+
+This can be done via [Homebrew](https://brew.sh/) and setting environment variables to point to relevant library and header files:
+
+```bash
+$ brew install openblas
+$ export SYSTEM_VERSION_COMPAT=1
+$ export LAPACK=/usr/local/opt/openblas/lib
+$ export LAPACK_SRC=/usr/local/opt/openblas/include
+$ export BLAS=/usr/local/opt/openblas/lib
+```
+
+Then run `pip install -e .`, as before.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ README = (HERE / "README.txt").read_text()
 setup(
     name="epilogos",
     version="0.0.1rc1",
-    authors=["Wouter Meuleman", "Jacob Quon", "Alex Reynolds", "Eric Rynes"],
+    author="Wouter Meuleman, Jacob Quon, Alex Reynolds, Eric Rynes",
+    author_email="wouter@meuleman.org",
     description="Information-theoretic navigation of multi-tissue functional genomic annotations",
     long_description=README,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from setuptools import setup, find_packages
 
@@ -6,6 +7,10 @@ HERE = pathlib.Path(__file__).parent
 
 # The text of the README file
 README = (HERE / "README.txt").read_text()
+
+# Requirements kept in one location
+REQUIREMENTS = (HERE / "requirements.txt").read_text()
+install_requirements = REQUIREMENTS.splitlines()
 
 setup(
     name="epilogos",
@@ -21,16 +26,7 @@ setup(
     # find_packages("epilogos", exclude=["src"]),
     scripts=["bin/preprocess_data_ChromHMM.sh"],
     include_package_data=True,
-    install_requires=[
-        "cython == 0.29.23",
-        "statsmodels == 0.12.0",
-        "scipy == 1.5.2",
-        "numpy == 1.19.2",
-        "matplotlib == 3.3.2",
-        "click == 7.1.2",
-        "pandas == 1.1.3",
-        "pyranges == 0.0.97",
-        ],
+    install_requires=install_requirements,
     entry_points={
         "console_scripts": [
             "epilogos = epilogos.__main__:main",


### PR DESCRIPTION
Running the following under Python 3.9.4 resulted in a warning:

```
$ python ./setup.py --help
/Users/areynolds/miniconda3/envs/epilogos_052421/lib/python3.9/distutils/dist.py:274: UserWarning: Unknown distribution option: 'authors'
  warnings.warn(msg)
...
```

The patch changes the value of `authors` to `author` and adds the `author_email` property, to provide contact information.