### PR TITLE
Patch suggestion for running minimal, non-Slurm single mode test

### DIFF
--- a/epilogos/epilogos.py
+++ b/epilogos/epilogos.py
@@ -51,7 +51,7 @@ def main(mode, commandLineBool, inputDirectory, inputDirectory1, inputDirectory2
         outputDirPath = Path.cwd() / outputDirPath
 
     # Make sure argments are valid
-    checkArguments(mode, saliency, inputDirPath, inputDirPath2, outputDirPath, numProcesses, numStates, quiescentState)
+    checkArguments(mode, saliency, inputDirPath, inputDirPath2, outputDirPath, numProcesses, numStates, quiescentState, groupSize)
 
     # Informing user of their inputs
     print()
@@ -234,6 +234,13 @@ def main(mode, commandLineBool, inputDirectory, inputDirectory1, inputDirectory2
         checkExit(mode, allJobIDs, expJobIDArr, scoreJobIDArr, outputDirPath, saliency)
         
 
+def isChangedFromDefault(name, arg):
+    defaults = {
+        "groupSize": -1,
+    }
+    return False if name not in defaults.keys() or arg != defaults[name] else True
+
+
 def checkFlags(mode, commandLineBool, inputDirectory, inputDirectory1, inputDirectory2, outputDirectory, stateInfo, saliency,
     numProcesses, exitBool, diagnosticBool, numTrials, samplingSize, quiescentState, groupSize):
     """
@@ -273,7 +280,7 @@ def checkFlags(mode, commandLineBool, inputDirectory, inputDirectory1, inputDire
     elif mode[0] == "single" and quiescentState:
         print("ERROR: [-m, --mode] 'single' not compatible with [-q, --quiescent-state] flag")
         sys.exit()
-    elif mode[0] == "single" and groupSize:
+    elif mode[0] == "single" and isChangedFromDefault('groupSize', groupSize):
         print("ERROR: [-m, --mode] 'single' not compatible with [-g, --group-size] flag")
         sys.exit()
     elif mode[0] == "paired" and inputDirectory:


### PR DESCRIPTION
This PR is a suggestion. It may not be the way you want to fix things.

The code at issue is in the `checkFlags()` function:

```
    elif mode[0] == "single" and groupSize:
        print("ERROR: [-m, --mode] 'single' not compatible with [-g, --group-size] flag")
        sys.exit()
```

The issue is that a default value for `groupSize` is defined in `__main__.py`:

```
@click.option("-g", "--group-size", "groupSize", type=int, default=[-1], show_default=True, multiple=True,
              help="In pairwise epilogos controls the sizes of the shuffled arrays. Default is sizes of the input groups")
```

The test `mode[0] == "single" and groupSize` will pass, because at this step, `groupSize` is a tuple set to `(-1,)`.

What I suggest is to check if this default is changed to some other value, which you'd want to catch:

```
def isChangedFromDefault(name, arg):
    defaults = {
        "groupSize": -1,
    }
    return False if name not in defaults.keys() or arg != defaults[name] else True
```

Then modify the test:

```
    elif mode[0] == "single" and isChangedFromDefault('groupSize', groupSize):
        print("ERROR: [-m, --mode] 'single' not compatible with [-g, --group-size] flag")
        sys.exit()
```

If there are other options that need to be tested in a similar way, you just have to add an entry to the `defaults` dictionary and make a similar call for other option checks.